### PR TITLE
[Docker] Update local docker-compose network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@
 version: '3.5'
 
 networks:
-  empurrando-juntos:
-    name: empurrando-juntos
+  ej:
+    name: ej
 
 services:
   nginx:
@@ -13,7 +13,7 @@ services:
     ports:
       - '80:80'
     networks:
-      - empurrando-juntos
+      - ej
 
   angular:
     environment:
@@ -30,4 +30,4 @@ services:
     volumes:
       - .:/app
     networks:
-      - empurrando-juntos
+      - ej


### PR DESCRIPTION
The [ej-server](https://github.com/ejplatform/ej-server) [local docker-compose](https://github.com/ejplatform/ej-server/blob/develop/local.yml) changed the network name to `ej`. In order to `ej-front` communicate with the `ej-server`, the network must be the same.